### PR TITLE
Added me_request to auth object

### DIFF
--- a/coffee/lib/authentication.coffee
+++ b/coffee/lib/authentication.coffee
@@ -32,6 +32,8 @@ module.exports = (cache, requestio) ->
 					return requestio.make_request(response, 'PUT', url, options)
 				response.del = (url, options) ->
 					return requestio.make_request(response, 'DELETE', url, options)
+				response.me = (options) ->
+					return requestio.make_me_request(response, options)
 				if (req?.session?)
 					req.session.oauth = req.session.oauth || {}
 					req.session.oauth[response.provider] = response


### PR DESCRIPTION
The .me() function is available if you .create() a new object but it's not within the object that is returned when you authenticate. Now the objects that is returned by the authentication module is the same as the one that you would create manually and makes .me accessible for the returned promise within an auth() call
