### PR TITLE
Redirect: do not call next after res.end()

### DIFF
--- a/coffee/lib/authentication.coffee
+++ b/coffee/lib/authentication.coffee
@@ -47,7 +47,6 @@ module.exports = (csrf_generator, cache, requestio) ->
 			csrf_token = csrf_generator(req.session)
 			res.writeHead 302, Location: cache.oauthd_url + cache.oauthd_base + '/' + provider + '?k=' + cache.public_key + '&opts=' + encodeURIComponent(JSON.stringify({state: csrf_token})) + '&redirect_type=server&redirect_uri=' + encodeURIComponent(urlToRedirect)
 			res.end()
-			next()
 
 		auth: (provider, session, opts) ->
 			defer = Q.defer()


### PR DESCRIPTION
Express applications may have final handlers (e.g. to serve 404 pages or log errors), calling `next` after `res.end` will cause these handlers to be triggered when they should not.

If the application has a default page handler (common in SPAs with client-side routing) or 404 page, calling `next` after `res.end` will throw a "headers already sent" error.